### PR TITLE
Enable frozen cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.1.1 (24 August 2024)
+
+### Patch Release
+
+* Add `xpack.searchable.snapshot.shared_cache.size=50M"` to `create.sh`
+  * After discovering unassigned shards in my frozen index testing, I
+    discovered that `client.cluster.allocation_explain()` revealed the
+    problem: 
+    
+    ```
+    'allocate_explanation': "Elasticsearch isn't allowed to allocate this shard to any of the nodes in the cluster.
+    ```
+
+    A bit farther in, I saw:
+
+    ```
+    'explanation': 'node setting [xpack.searchable.snapshot.shared_cache.size]
+    is set to zero, so shards of partially mounted indices cannot be
+    allocated to this node'}]
+    ```
+
+    The solution became apparent after that.
+
 ## 1.1.0 (24 August 2024)
 
 ### Feature Release

--- a/docker_test/VERSION
+++ b/docker_test/VERSION
@@ -1,4 +1,4 @@
-Version: 1.1.0
+Version: 1.1.1
 Released: 24 August 2024
 
 # License and Changelog at https://github.com/untergeek/es-docker-test-scripts

--- a/docker_test/create.sh
+++ b/docker_test/create.sh
@@ -42,6 +42,7 @@ docker run -q -d -it --name ${NAME} --network ${NAME}-net -m ${MEMORY} \
   -e "cluster.name=local-cluster" \
   -e "node.name=local-node" \
   -e "xpack.monitoring.templates.enabled=false" \
+  -e "xpack.searchable.snapshot.shared_cache.size=50M" \
   -e "path.repo=${REPODOCKER}" \
 ${IMAGE}:${VERSION}
 


### PR DESCRIPTION
## Patch Release

### Add `xpack.searchable.snapshot.shared_cache.size=50M"` to `create.sh`

After discovering unassigned shards in my frozen index testing, I discovered that `client.cluster.allocation_explain()` revealed the problem:

```
'allocate_explanation': "Elasticsearch isn't allowed to allocate this shard to any of the nodes
in the cluster.
```

A bit farther in, I saw:

```
'explanation': 'node setting [xpack.searchable.snapshot.shared_cache.size] is set to zero, so
shards of partially mounted indices cannot be allocated to this node'}]
```

The solution became apparent after that.