### PR TITLE
Lots of updates making multiple nodes possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+docker_test/.kurl
+docker_test/repo
+http_ca.crt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## 1.2.0 (30 August 2024)
+
+### Feature Release
+
+* Add `scenarios.bash` as a source-able file to set variables based on the
+  scenario. It's likely to just be a bunch of `case` statements.
+
+* Add a `.gitignore` file
+
+* Massive updates to `common.bash`:
+
+  * Variables and Constants:
+
+    * `JAVA_OPTS="-Xms512m -Xmx512m"` for overriding half of `MEMORY`, if desired.
+    * `CLUSTER_NAME="docker_test"` set a new default cluster name.
+    * `DISCOVERY_TYPE="single-node"` This is the default for a single node,
+      but can be overriden for multi-node clusters.
+    * `TRUNK=${PROJECT_NAME}-test` for making it easier to find multiple, similar nodes
+    * `NUM=0` for appending a numeric value to the container name
+    * `NAME=${TRUNK}-${NUM}` for naming the initial container
+
+  * Functions
+
+    * Add `initial_value` function to extract not only the Elasticsearch
+      password, but now also the node enrollment token.
+    * Updated `xpack_fork` to be quieter, to use `initial_value`, to not
+      pre-emptively delete `${ENVCFG}` and `${CURLCFG}` in case another
+      script sources `common.bash`.
+    * Add `url_check` function to outsource repeat aliveness checks.
+    * Add `start_container` function to easily add additional nodes.
+
+* Massive updates to `create.sh`:
+
+  * Variables and Constants:
+
+    * `NODECOUNT=1` for the initial count of nodes to start
+    * `ROLES=...` to set node roles
+    * Added a second command-line argument to define a setup SCENARIO
+    * Added `ES_VERSION` as an environment variable in `${ENVCFG}`
+
+  * Execution flow changes
+
+    * If a SCENARIO is provided at the command-line as the second argument,
+      source `scenarios.bash` and have those variables imported as a result.
+
+      * These include (so far) updating:
+ 
+        * `NODECOUNT`
+        * `DISCOVERY_TYPE`
+        * `ROLES`
+
+    * Update what is displayed during node creation
+    * Call `start_container` to start nodes
+    * Loop from 2 through the value of `NODECOUNT` and create new nodes with
+      the values of [enrollment] `TOKEN`, `DISCOVERY_TYPE`, and `ROLES`
+
+      * Check each node for aliveness as it comes up.
+
+* Updates to `destroy.sh`
+
+  * Add a `verbose` command-line option, which if specified, will show all
+    containers being stopped and deleted.
+  * Add a logging function to check if `verbose` was specified.
+
+* Add `scenarios.bash`
+
+  * Essentially a big `case` statement to assign or update variables for
+    `create.sh` runs, based on the value of SCENARIO.
+  * Added the `frozen_node` scenario, which sets:
+
+    * `NODECOUNT=2`
+    * `DISCOVERY_TYPE="multi-node"`
+    * `ROLES="data_frozen"`
+
+  * If a SCENARIO is specified, but does not match, print out an error to the
+    command-line and exit
+  
+ 
 ## 1.1.1 (24 August 2024)
 
 ### Patch Release

--- a/docker_test/VERSION
+++ b/docker_test/VERSION
@@ -1,4 +1,4 @@
-Version: 1.1.1
-Released: 24 August 2024
+Version: 1.2.0
+Released: 30 August 2024
 
 # License and Changelog at https://github.com/untergeek/es-docker-test-scripts

--- a/docker_test/common.bash
+++ b/docker_test/common.bash
@@ -16,6 +16,9 @@ REPONAME=testing
 LIMIT=30  # How many seconds to wait to obtain the credentials
 IMAGE=docker.elastic.co/elasticsearch/elasticsearch
 MEMORY=1GB  # The heap will be half of this
+JAVA_OPTS="-Xms512m -Xmx512m"
+CLUSTER_NAME="docker_test"
+DISCOVERY_TYPE="single-node"
 
 
 #############################
@@ -25,6 +28,34 @@ MEMORY=1GB  # The heap will be half of this
 docker_logline () {
   # Return the line number that contains "${1}"
   echo $(docker logs ${NAME} | grep -n "${1}" | awk -F\: '{print $1}')
+}
+
+initial_value () {
+  # $1 is the value representation
+  local searchstr=''
+
+  case ${1} in
+    
+    'password') 
+      searchstr='elasticsearch-reset-password'
+      ;;
+
+    'nodetoken') 
+      searchstr='\--enrollment-token'
+      ;;
+
+  esac
+
+  local linenum=$(docker_logline ${searchstr})
+
+  # Increment the linenum (because we want the next line)
+  ((++linenum))
+
+  # Get the (next) line, i.e. incremented and tailed to isolate
+  retval=$(docker logs ${NAME} | head -n ${linenum} | tail -1 | awk '{print $1}')
+
+  # Strip the ANSI color/bold here. External function because of the control-M sequence
+  ansi_clean "${retval}"
 }
 
 get_espw () {
@@ -74,14 +105,8 @@ get_espw () {
     exit 1
   fi
   
-  # Increment the linenum (because we want the next line)
-  ((++linenum))
-
-  # Get the (next) line, i.e. incremented and tailed to isolate
-  retval=$(docker logs ${NAME} | head -n ${linenum} | tail -1 | awk '{print $1}')
-
-  # Strip the ANSI color/bold here. External function because of the control-M sequence
-  ESPWD=$(ansi_clean "${retval}")
+  ESPWD=$(initial_value 'password')
+  NODETOKEN=$(initial_value 'nodetoken')
 }
 
 change_espw () {
@@ -127,11 +152,9 @@ change_espw () {
 
 xpack_fork () {
 
-  echo
-  echo "Getting Elasticsearch credentials from container \"${NAME}\"..."
-  echo
+  echo "Getting Elasticsearch credentials from container ${NAME}..."
 
-  # Get the password from the change_espw function. It sets ESPWD
+  # Get the password from the get_espw function. It sets ESPWD
   get_espw 
 
   # If we have an empty value, that's a problem
@@ -143,6 +166,7 @@ xpack_fork () {
   # Put envvars in ${ENVCFG}
   echo "export ESCLIENT_USERNAME=${ESUSR}" >> ${ENVCFG}
   echo "export TEST_USER=${ESUSR}" >> ${ENVCFG}
+
   # We escape the quotes so we can include them in case of special characters
   echo "export ESCLIENT_PASSWORD=\"${ESPWD}\"" >> ${ENVCFG}
   echo "export TEST_PASS=\"${ESPWD}\"" >> ${ENVCFG}
@@ -156,7 +180,7 @@ xpack_fork () {
   echo "--cacert ${CACRT}" >> ${CURLCFG}
 
   # Complete
-  echo "Credentials captured!"
+  # echo "Credentials captured!"
 }
 
 # Save original execution path
@@ -206,11 +230,9 @@ CACRT=${PROJECT_ROOT}/http_ca.crt
 
 # Set the .env file
 ENVCFG=${PROJECT_ROOT}/${ENVFILE}
-rm -rf ${ENVCFG}
 
 # Set the curl config file and ensure we're not reusing an old one
 CURLCFG=${SCRIPTPATH}/${CURLFILE}
-rm -rf ${CURLCFG}
 
 # Determine local IPs
 OS=$(uname -a | awk '{print $1}')
@@ -229,8 +251,14 @@ fi
 ### Set Docker vars ###
 #######################
 
+# Set the TRUNK
+TRUNK=${PROJECT_NAME}-test
+
+# Set the Docker container number
+NUM=0
+
 # Set the Docker container name
-NAME=${PROJECT_NAME}-test
+NAME=${TRUNK}-${NUM}
 
 # Set the bind mount path for the snapshot repository
 REPOLOCAL=${SCRIPTPATH}/repo
@@ -238,6 +266,98 @@ REPOLOCAL=${SCRIPTPATH}/repo
 # Navigate back to the script path
 cd ${SCRIPTPATH}
 
-###################
+############################
+### URL CHECKER FUNCTION ###
+############################
+
+check_url () {
+
+  # URL = $1
+  # EXPECTED = $2
+
+  if [ "x${EXPECTED}" == "x" ]; then
+    local EXPECTED=200
+  else
+    local EXPECTED=${2}
+  fi
+
+  # Start with an empty value
+  local ACTUAL=0
+
+  # Initialize loop counter
+  local COUNTER=0
+
+  # Loop until we get our 200 code
+  while [ "${ACTUAL}" != "${EXPECTED}" ] && [ ${COUNTER} -lt ${LIMIT} ]; do
+
+    # Get our actual response
+    ACTUAL=$(curl -K ${CURLCFG} ${1})
+
+    # If we got what we expected, we're great!
+    if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+      # Sleep and try again
+      sleep 1
+      ((++COUNTER))
+    fi
+
+  done
+  # End while loop
+
+  # If we still don't have what we expected, we hit the LIMIT
+  if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+
+    echo "Unable to connect to ${1} in ${LIMIT} seconds. Unable to continue. Exiting..."
+    exit 1
+  fi
+
+  echo ${ACTUAL}
+}
+
+################################
+### Start a Docker container ###
+################################
+
+start_container () {
+  # $1 node_number
+  # $2 enrollment_token
+  # $3 node roles
+
+  if [ "x${2}" == "x" ]; then
+    local token=''
+  else
+    local token=${2}
+  fi
+
+  if [ "x${3}" == "x" ]; then
+    local roles="'data', 'data_cold', 'data_content', 'data_hot', 'data_warm', 'ingest', 'master'"
+  else
+    local roles="${3}"
+  fi
+
+  local fromzero=$(( ${1} - 1 ))
+  local nodename="${TRUNK}-${fromzero}"
+  local portnum=$(( 9200 + ${fromzero} ))
+
+echo -en "Container ID: "
+docker run -q -d -it \
+  --name ${nodename} \
+  --network ${TRUNK}-net \
+  -m ${MEMORY} \
+  -p ${portnum}:${DOCKER_PORT} \
+  -v ${REPOLOCAL}:${REPODOCKER} \
+  -e ENROLLMENT_TOKEN="${token}" \
+  -e ES_JAVA_OPTS="${JAVA_OPTS}" \
+  -e "discovery.type=${DISCOVERY_TYPE}" \
+  -e "cluster.name=${CLUSTER_NAME}" \
+  -e "node.name=node-${fromzero}" \
+  -e "node.roles=[${roles}]" \
+  -e "xpack.searchable.snapshot.shared_cache.size=100MB" \
+  -e "xpack.monitoring.templates.enabled=false" \
+  -e "path.repo=${REPODOCKER}" \
+${IMAGE}:${VERSION}
+
+}
+
+##################
 ### END COMMON ###
-###################
+##################

--- a/docker_test/create.sh
+++ b/docker_test/create.sh
@@ -5,17 +5,31 @@
 source $(dirname "$0")/common.bash
 
 echo
+NODECOUNT=1
+ROLES="\"data\", \"data_content\", \"data_hot\", \"data_warm\", \"data_cold\", \"master\", \"ingest\""
 
 # Test to see if we were passed a VERSION
 if [ "x${1}" == "x" ]; then
   echo "Error! No Elasticsearch version provided."
   echo "VERSION must be in Semver format, e.g. X.Y.Z, 8.6.0"
-  echo "USAGE: ${0} VERSION"
+  echo "USAGE: ${0} VERSION [SCENARIO]" 
   exit 1
+fi
+
+# Test to see if we were passed another argument
+if [ "x${2}" != "x" ]; then
+  source ${SCRIPTPATH}/scenarios.bash
+  echo "Using scenario: ${2}"
 fi
 
 # Set the version
 VERSION=${1}
+# Add ES_VERSION to ${ENVCFG}
+echo "export ES_VERSION=${VERSION}" >> ${ENVCFG}
+
+# Start console output
+echo "Using Elasticsearch version ${VERSION}"
+echo
 
 ######################################
 ### Setup snapshot repository path ###
@@ -29,27 +43,21 @@ mkdir -p ${REPOLOCAL}
 ### Run Container ###
 #####################
 
-docker network rm -f ${NAME}-net > /dev/null 2>&1
-docker network create ${NAME}-net > /dev/null 2>&1
+docker network rm -f ${TRUNK}-net > /dev/null 2>&1
+docker network create ${TRUNK}-net > /dev/null 2>&1
+
 
 # Start the container
-echo "Starting container \"${NAME}\" from ${IMAGE}:${VERSION}"
-echo -en "Container ID: "
-docker run -q -d -it --name ${NAME} --network ${NAME}-net -m ${MEMORY} \
-  -p ${LOCAL_PORT}:${DOCKER_PORT} \
-  -v ${REPOLOCAL}:${REPODOCKER} \
-  -e "discovery.type=single-node" \
-  -e "cluster.name=local-cluster" \
-  -e "node.name=local-node" \
-  -e "xpack.monitoring.templates.enabled=false" \
-  -e "xpack.searchable.snapshot.shared_cache.size=50M" \
-  -e "path.repo=${REPODOCKER}" \
-${IMAGE}:${VERSION}
+echo "Creating ${NODECOUNT} node(s)..."
+echo 
+
+echo "Starting node 1..."
+start_container "1"
 
 # Set the URL
 URL=https://${URL_HOST}:${LOCAL_PORT}
 
-# Add TESTPATH to ${ENVCFG}, creating it or overwriting it
+# Add TESTPATH to ${ENVCFG}
 echo "export CA_CRT=${PROJECT_ROOT}/http_ca.crt" >> ${ENVCFG}
 echo "export TEST_PATH=${TESTPATH}" >> ${ENVCFG}
 echo "export TEST_ES_SERVER=${URL}" >> ${ENVCFG}
@@ -66,6 +74,7 @@ echo '-w "%{http_code}\n"' >> ${CURLCFG}
 
 # Do the xpack_fork function, passing the container name and the .env file path
 xpack_fork "${NAME}" "${ENVCFG}"
+echo
 
 # Did we get a bad return code?
 if [ $? -eq 1 ]; then
@@ -75,51 +84,7 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
-# We expect a 200 HTTP rsponse
-EXPECTED=200
-
-# Set the NODE var
-NODE="${NAME} instance"
-
-# Start with an empty value
-ACTUAL=0
-
-# Initialize loop counter
-COUNTER=0
-
-# Loop until we get our 200 code
-echo
-while [ "${ACTUAL}" != "${EXPECTED}" ] && [ ${COUNTER} -lt ${LIMIT} ]; do
-
-  # Get our actual response
-  ACTUAL=$(curl -K ${CURLCFG} ${URL})
-
-  # Report what we received
-  echo -en "\rHTTP status code for ${NODE} is: ${ACTUAL}"
-
-  # If we got what we expected, we're great!
-  if [ "${ACTUAL}" == "${EXPECTED}" ]; then
-    echo " --- ${NODE} is ready!"
-
-  else
-    # Otherwise sleep and try again 
-    sleep 1
-    ((++COUNTER))
-  fi
-
-done
-# End while loop
-
-# If we still don't have what we expected, we hit the LIMIT
-if [ "${ACTUAL}" != "${EXPECTED}" ]; then
-  
-  echo "Unable to connect to ${URL} in ${LIMIT} seconds. Unable to continue. Exiting..." 
-  exit 1
-
-fi
-
 # Initialize trial license
-echo
 response=$(curl -s \
   --cacert ${CACRT} -u "${ESUSR}:${ESPWD}" \
   -XPOST "${URL}/_license/start_trial?acknowledge=true")
@@ -127,8 +92,9 @@ response=$(curl -s \
 expected='{"acknowledged":true,"trial_was_started":true,"type":"trial"}'
 if [ "$response" != "$expected" ]; then
   echo "ERROR! Unable to start trial license!"
+  exit 1
 else
-  echo -n "Trial license started and acknowledged. "
+  echo "Trial license started..."
 fi
 
 # Set up snapshot repository. The following will create a JSON file suitable for use with
@@ -156,19 +122,30 @@ response=$(curl -s \
 expected='{"acknowledged":true}'
 if [ "$response" != "$expected" ]; then
   echo "ERROR! Unable to create snapshot repository"
+  exit 1
 else
-  echo "Snapshot repository \"${REPONAME}\" created."
+  echo "Snapshot repository initialized..."
   rm -f ${REPOJSON}
 fi
 
+echo
+echo "Node 1 started."
+
+if [ ${NODECOUNT} -gt 1 ]; then
+  for i in $(seq 2 ${NODECOUNT}); do
+    CAPTURE=$(start_container "${i}" "${NODETOKEN}" "${ROLES}")
+    testport=$(( 9200 + ${i} -1 ))
+    CAPTURE=$(check_url "https://${URL_HOST}:${testport}")
+    echo "Node ${i} started."
+  done
+fi
 
 ##################
 ### Wrap it up ###
 ##################
 
 echo
-echo "${NAME} container is up using image elasticsearch:${VERSION}"
-echo "Ready to test!"
+echo "All nodes ready to test!"
 echo
 
 if [ "$EXECPATH" == "$PROJECT_ROOT" ]; then

--- a/docker_test/destroy.sh
+++ b/docker_test/destroy.sh
@@ -1,24 +1,39 @@
 #!/bin/bash
 
+if [ "x${1}" != "verbose" ]; then
+  DEBUG=0
+else
+  DEBUG=1
+fi
+
 # Source the common.bash file from the same path as the script
 source $(dirname "$0")/common.bash
 
-echo
+log_out () {
+  # $1 is the log line
+  if [ ${DEBUG} -eq 1 ]; then
+    echo ${1}
+  fi
+}
 
-# Stop and remove the docker container
-RUNNING=$(docker ps -f name=${NAME} | grep -v NAMES | awk '{print $NF}')
-EXISTS=$(docker ps -af name=${NAME} | grep -v NAMES | awk '{print $NF}')
-if [ "${RUNNING}" == "${NAME}" ]; then
-  echo "Stopping container ${NAME}..."
-  echo "$(docker stop ${NAME}) stopped."
-fi
-if [ "${EXISTS}" == "${NAME}" ]; then
-  echo "Removing container ${NAME}..."
-  echo "$(docker rm -f ${NAME}) deleted."
-fi
+# Stop running containers
+echo "Stopping all containers..."
+RUNNING=$(docker ps | grep -v NAMES | grep ${TRUNK} | awk '{print $NF}')
+for container in ${RUNNING}; do
+  log_out "Stopping container ${container}..."
+  log_out "$(docker stop ${container}) stopped."
+done
+
+# Remove existing containers
+echo "Removing all containers..."
+EXISTS=$(docker ps -a | grep -v NAMES | grep ${TRUNK} | awk '{print $NF}')
+for container in ${EXISTS}; do
+  log_out "Removing container ${container}..."
+  log_out "$(docker rm -f ${container}) deleted."
+done
 
 # Delete Docker network
-docker network rm -f ${NAME}-net > /dev/null 2>&1
+docker network rm -f ${TRUNK}-net > /dev/null 2>&1
 
 # Delete .env file and curl config file
 echo "Deleting remaining files and directories"

--- a/docker_test/scenarios.bash
+++ b/docker_test/scenarios.bash
@@ -1,0 +1,18 @@
+# Docker environment setup scenarios
+
+case ${2} in
+
+  'frozen_node')
+    NODECOUNT=2
+    DISCOVERY_TYPE="multi-node"
+    ROLES="data_frozen"
+    ;;
+
+  *)
+    echo "Error! SCENARIO not recognized."
+    echo "USAGE: ${0} VERSION [SCENARIO]"
+    echo "You entered: ${2}"
+    exit 1
+    ;;
+
+esac


### PR DESCRIPTION
## Release prep for 1.2.0 (30 August 2024)

### Feature Release

* Add `scenarios.bash` as a source-able file to set variables based on the scenario. It's likely to just be a bunch of `case` statements.

* Add a `.gitignore` file

* Massive updates to `common.bash`:

  * Variables and Constants:

    * `JAVA_OPTS="-Xms512m -Xmx512m"` for overriding half of `MEMORY`, if desired.
    * `CLUSTER_NAME="docker_test"` set a new default cluster name. * `DISCOVERY_TYPE="single-node"` This is the default for a single node, but can be overriden for multi-node clusters. * `TRUNK=${PROJECT_NAME}-test` for making it easier to find multiple, similar nodes * `NUM=0` for appending a numeric value to the container name * `NAME=${TRUNK}-${NUM}` for naming the initial container

  * Functions

    * Add `initial_value` function to extract not only the Elasticsearch password, but now also the node enrollment token.
    * Updated `xpack_fork` to be quieter, to use `initial_value`, to not pre-emptively delete `${ENVCFG}` and `${CURLCFG}` in case another script sources `common.bash`. * Add `url_check` function to outsource repeat aliveness checks. * Add `start_container` function to easily add additional nodes.

* Massive updates to `create.sh`:

  * Variables and Constants:

    * `NODECOUNT=1` for the initial count of nodes to start
    * `ROLES=...` to set node roles * Added a second command-line argument to define a setup SCENARIO * Added `ES_VERSION` as an environment variable in `${ENVCFG}`

  * Execution flow changes

    * If a SCENARIO is provided at the command-line as the second argument, source `scenarios.bash` and have those variables imported as a result.

      * These include (so far) updating:

        * `NODECOUNT`
        * `DISCOVERY_TYPE` 
        * `ROLES`

    * Update what is displayed during node creation * Call `start_container` to start nodes * Loop from 2 through the value of `NODECOUNT` and create new nodes with the values of [enrollment] `TOKEN`, `DISCOVERY_TYPE`, and `ROLES`

      * Check each node for aliveness as it comes up.

* Updates to `destroy.sh`

  * Add a `verbose` command-line option, which if specified, will show all containers being stopped and deleted.
  * Add a logging function to check if `verbose` was specified.

* Add `scenarios.bash`

  * Essentially a big `case` statement to assign or update variables for `create.sh` runs, based on the value of SCENARIO.
  * Added the `frozen_node` scenario, which sets:

    * `NODECOUNT=2`
    * `DISCOVERY_TYPE="multi-node"` 
    * `ROLES="data_frozen"`

  * If a SCENARIO is specified, but does not match, print out an error to the command-line and exit